### PR TITLE
omit deprecated IPv6 adresses

### DIFF
--- a/ddns-updater.sh
+++ b/ddns-updater.sh
@@ -34,7 +34,7 @@ providers=(
 ipv4_public=$(dig xxx.myfritz.net A +short)
 
 # obtain ipv6 of br0 device
-ipv6_public=$(ip -6 addr show dev br0 scope global | grep -oP "(?<=inet6 )[^/]+" | head -n 1)
+ipv6_public=$(ip -6 addr show dev br0 scope global -deprecated | grep -oP "(?<=inet6 )[^/]+" | head -n 1)
 
 # ######### Script ####################
 


### PR DESCRIPTION
filter out deprecated addresses which should not be used ( see https://man7.org/linux/man-pages/man8/ip-address.8.html ), e.g.:

For example with this configuration
```
81: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
[...]
    inet6 fd00::1234:4567:8910:f6db/64 scope global deprecated dynamic mngtmpaddr noprefixroute 
       valid_lft 7112sec preferred_lft 0sec
    inet6 2001:a61:1234:5678:9012:3456:7890:f6db/64 scope global dynamic mngtmpaddr noprefixroute 
       valid_lft 6471sec preferred_lft 2871sec
[...]
```
the script would currently report " fd00::1234:4567:8910:f6db" as public ip adress.